### PR TITLE
Address various linting issues

### DIFF
--- a/core/hashr/hashr.go
+++ b/core/hashr/hashr.go
@@ -321,7 +321,7 @@ func (h *HashR) handleError(ctx context.Context, quickHash, extractionBaseDir st
 	}
 }
 
-func (h *HashR) processingWorker(ctx context.Context, newSources <-chan Source, c *sync.Map) error {
+func (h *HashR) processingWorker(ctx context.Context, newSources <-chan Source, c *sync.Map) {
 	defer h.wg.Done()
 	for source := range newSources {
 		qHash, err := source.QuickSHA256Hash()
@@ -364,7 +364,7 @@ func (h *HashR) processingWorker(ctx context.Context, newSources <-chan Source, 
 		h.processingSourcesMutex.RUnlock()
 		samples, err := cache.Check(extraction, c)
 		if err != nil {
-			h.handleError(ctx, qHash, extraction.BaseDir, h.processingSources[qHash], err)
+			h.handleError(ctx, qHash, extraction.BaseDir, processingSource, err)
 			continue
 		}
 
@@ -420,7 +420,7 @@ func (h *HashR) processingWorker(ctx context.Context, newSources <-chan Source, 
 					h.processingSourcesMutex.RUnlock()
 				}
 			}
-			
+
 		} else {
 			err = h.saveSamples(source.RepoName(), extraction.SourceID, extraction.SourceSHA256, samples)
 			if err != nil {
@@ -448,8 +448,6 @@ func (h *HashR) processingWorker(ctx context.Context, newSources <-chan Source, 
 		h.mu.Unlock()
 		h.cacheSaveCounter++
 	}
-
-	return nil
 }
 
 func (h *HashR) saveSamples(sourceImporter, sourceID, sourceHash string, samples []common.Sample) error {

--- a/core/hashr/hashr_test.go
+++ b/core/hashr/hashr_test.go
@@ -27,6 +27,7 @@ import (
 	"cloud.google.com/go/spanner"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
 	instance "cloud.google.com/go/spanner/admin/instance/apiv1"
@@ -172,7 +173,7 @@ func TestRun(t *testing.T) {
 		o := []option.ClientOption{
 			option.WithEndpoint("localhost:9010"),
 			option.WithoutAuthentication(),
-			option.WithGRPCDialOption(grpc.WithInsecure()),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		}
 
 		instanceAdmin, err := instance.NewInstanceAdminClient(ctx, o...)

--- a/exporters/gcp/gcp_test.go
+++ b/exporters/gcp/gcp_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/hashr/common"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"cloud.google.com/go/spanner"
 	database "cloud.google.com/go/spanner/admin/database/apiv1"
@@ -58,7 +59,7 @@ func TestExport(t *testing.T) {
 	o := []option.ClientOption{
 		option.WithEndpoint("localhost:9010"),
 		option.WithoutAuthentication(),
-		option.WithGRPCDialOption(grpc.WithInsecure()),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 	}
 
 	instanceAdmin, err := instance.NewInstanceAdminClient(ctx, o...)

--- a/importers/deb/deb.go
+++ b/importers/deb/deb.go
@@ -102,7 +102,10 @@ func extractTar(tarfile *tar.Reader, outputFolder string) error {
 				return fmt.Errorf("error while creating destination file: %v", err)
 			}
 			defer unpackFileHandle.Close()
-			io.Copy(unpackFileHandle, tarfile)
+			_, err = io.Copy(unpackFileHandle, tarfile)
+			if err != nil {
+				return fmt.Errorf("error while writing to destination file: %v", err)
+			}
 
 		default:
 			fmt.Printf("Unknown tar entry type: %c in file %s\n", header.Typeflag, name)

--- a/importers/importer.go.example
+++ b/importers/importer.go.example
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package windows implements Windows ISO-13346 repository importer.
-package windows
+package template
 
 import (
 	"context"

--- a/importers/windows/windows.go
+++ b/importers/windows/windows.go
@@ -117,7 +117,11 @@ func extractWimFolder(wimFile *wim.File, path, extractionDir string) error {
 				glog.Errorf("Could not create destination directory %s: %v", dstPath, err)
 				continue
 			}
-			extractWimFolder(file, filepath.Join(path, file.Name), extractionDir)
+			err = extractWimFolder(file, filepath.Join(path, file.Name), extractionDir)
+			if err != nil {
+				glog.Errorf("Failed to extract Wim folder %s: %v", file.Name, err)
+				continue
+			}
 		} else {
 			if err := copyFile(file, dstPath); err != nil {
 				glog.Errorf("Could not copy to destination file %s: %v", dstPath, err)

--- a/importers/windows/windows.go
+++ b/importers/windows/windows.go
@@ -117,10 +117,8 @@ func extractWimFolder(wimFile *wim.File, path, extractionDir string) error {
 				glog.Errorf("Could not create destination directory %s: %v", dstPath, err)
 				continue
 			}
-			err = extractWimFolder(file, filepath.Join(path, file.Name), extractionDir)
-			if err != nil {
-				glog.Errorf("Failed to extract Wim folder %s: %v", file.Name, err)
-				continue
+			if err := extractWimFolder(file, filepath.Join(path, file.Name), extractionDir); err != nil {
+				glog.Warningf("Failed to extract Wim folder %s: %v", file.Name, err)
 			}
 		} else {
 			if err := copyFile(file, dstPath); err != nil {

--- a/processors/local/local.go
+++ b/processors/local/local.go
@@ -158,7 +158,7 @@ func xfsVolumes(imagePath string, volumes []volume) ([]volume, error) {
 			continue
 		}
 		// Check if first 4 bytes of the volume matches XFS signature.
-		if bytes.Compare(data, []byte{88, 70, 83, 66}) == 0 {
+		if bytes.Equal(data, []byte{88, 70, 83, 66}) {
 			xfsPartitions = append(xfsPartitions, volume)
 		}
 	}


### PR DESCRIPTION
* Remove error return type from processingWorker as it is always nil and never checked.
* Use variable read from locked dict
* grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials()
* Check return value of io.Copy
* Rename importer template to stop treating it as Go code that's used
* Check return value of extractWimFolder()
* Use bytes.Equal(...) instead of bytes.Compare(...) == 0