### PR TITLE
HashR docker documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HashR: Generate your own set of hashes 
+# HashR: Generate your own set of hashes
 
 <img src="docs/assets/HashR.png" width="800"> <br><br>
 
@@ -10,6 +10,7 @@
   - [Requirements](#requirements)
   - [Building HashR binary and running tests](#building-hashr-binary-and-running-tests)
   - [Setting up HashR](#setting-up-hashr)
+    - [HashR using docker](#hashr-using-docker)
     - [OS configuration \& required 3rd party tooling](#os-configuration--required-3rd-party-tooling)
     - [Setting up storage for processing tasks](#setting-up-storage-for-processing-tasks)
       - [Setting up PostgreSQL storage](#setting-up-postgresql-storage)
@@ -29,7 +30,7 @@
       - [Setting up GCP exporter](#setting-up-gcp-exporter)
     - [Additional flags](#additional-flags)
 
-## About 
+## About
 
 HashR allows you to build your own hash sets based on your data sources. It's a tool that extracts files and hashes out of input sources (e.g. raw disk image, GCE disk image, ISO file, Windows update package, .tar.gz file, etc.).
 
@@ -39,44 +40,44 @@ HashR consists of the following components:
 1. Core, which takes care of extracting the content from the source using image_export.py (Plaso), caching and repository level deduplication and preparing the extracted files for the exporters.
 1. Exporters, which are responsible for exporting files, metadata and hashes to given data sinks.
 
-Currently implemented importers: 
+Currently implemented importers:
 
 1. GCP, which extracts file from base GCP disk [images](https://cloud.google.com/compute/docs/images)
-1. Windows, which extracts files from Windows installation media in ISO-13346 format. 
+1. Windows, which extracts files from Windows installation media in ISO-13346 format.
 1. WSUS, which extracts files from Windows Update packages.
 1. GCR, which extracts file from container images stored in Google Container Registry.
-1. TarGz, which extracts files from .tar.gz archives. 
+1. TarGz, which extracts files from .tar.gz archives.
 1. Deb, which extracts files Debian software packages.
 1. RPM, which extracts files from RPM software packages.
-1. Zip, which extracts files from .zip (and zip-like) archives. 
+1. Zip, which extracts files from .zip (and zip-like) archives.
 
 Once files are extracted and hashed results will be passed to the exporters, currently implemented exporters:
 
-1. PostgreSQL, which upload the data to PostgreSQL instance. 
-1. Cloud Spanner, which uploads the data to GCP Spanner instance. 
+1. PostgreSQL, which upload the data to PostgreSQL instance.
+1. Cloud Spanner, which uploads the data to GCP Spanner instance.
 
-You can choose which importers you want to run, each one have different requirements. More about this can be found in sections below. 
+You can choose which importers you want to run, each one have different requirements. More about this can be found in sections below.
 
 
 ## Requirements
 
-HashR requires Linux OS to run, this can be a physical, virtual or cloud machine. Below are optimal hardware requirements: 
+HashR requires Linux OS to run, this can be a physical, virtual or cloud machine. Below are optimal hardware requirements:
 
-1. 8-16 cores 
-1. 128GB memory 
+1. 8-16 cores
+1. 128GB memory
 1. 2TB fast local storage (SSDs preferred)
 
 HashR can likely run how machines with lower specifications, however this was not thoroughly tested.
 
-## Building HashR binary and running tests 
+## Building HashR binary and running tests
 
-In order to build a hashr binary run the following command: 
+In order to build a hashr binary run the following command:
 
 ``` shell
 env GOOS=linux GOARCH=amd64 go build hashr.go
 ```
 
-In order to run tests for the core hashR package you need to run Spanner emulator: 
+In order to run tests for the core hashR package you need to run Spanner emulator:
 
 ``` shell
 gcloud emulators spanner start
@@ -90,9 +91,13 @@ go test -timeout 2m ./...
 
 ## Setting up HashR
 
-### OS configuration & required 3rd party tooling 
+### HashR using docker
 
-HashR takes care of the heavy lifting (parsing disk images, volumes, file systems) by using Plaso. You need to pull the Plaso docker container using the following command: 
+To run HashR in a docker container visit the [docker specific guide](docker/README.md)
+
+### OS configuration & required 3rd party tooling
+
+HashR takes care of the heavy lifting (parsing disk images, volumes, file systems) by using Plaso. You need to pull the Plaso docker container using the following command:
 
 ``` shell
 docker pull log2timeline/plaso
@@ -101,10 +106,10 @@ docker pull log2timeline/plaso
 We also need 7z, which is used by WSUS importer for recursive extraction of Windows Update packages, to be installed on the machine running HashR:
 
 ``` shell
-sudo apt install p7zip-full 
+sudo apt install p7zip-full
 ```
 
-You need to allow the user, under which HashR will run, to run certain commands via sudo. Assuming that your user is `hashr` create a file `/etc/sudoers.d/hashr` and put in: 
+You need to allow the user, under which HashR will run, to run certain commands via sudo. Assuming that your user is `hashr` create a file `/etc/sudoers.d/hashr` and put in:
 
 ``` shell
 hashr ALL = (root) NOPASSWD: /bin/mount,/bin/umount,/sbin/losetup,/bin/rm
@@ -121,10 +126,10 @@ sudo usermod -aG docker hashr
 
 HashR needs to store information about processed sources. It also stores additional telemetry about processing tasks: processing times, number of extracted files, etc. You can choose between using:
 
-1. PostgreSQL 
+1. PostgreSQL
 1. Cloud (GCP) Spanner
 
-#### Setting up PostgreSQL storage 
+#### Setting up PostgreSQL storage
 
 There are many ways you can run and maintain your PostgreSQL instance, one of the simplest ways would be to run it in a Docker container. Follow the steps below to set up a PostgreSQL Docker container.
 
@@ -134,7 +139,7 @@ Step 1: Pull the PostgreSQL docker image.
 docker pull postgres
 ```
 
-Step 2: Initialize and run the PostgreSQL container in the background. Make sure to adjust the password. 
+Step 2: Initialize and run the PostgreSQL container in the background. Make sure to adjust the password.
 
 ``` shell
 docker run -itd -e POSTGRES_DB=hashr -e POSTGRES_USER=hashr -e POSTGRES_PASSWORD=hashr -p 5432:5432 -v /data:/var/lib/postgresql/data --name hashr_postgresql postgres
@@ -166,7 +171,7 @@ Create service account key and store in your home directory. Set *<project_name>
 gcloud iam service-accounts keys create ~/hashr-sa-private-key.json --iam-account=hashr-sa@<project_name>.iam.gserviceaccount.com
 ```
 
-Point GOOGLE_APPLICATION_CREDENTIALS env variable to your service account key: 
+Point GOOGLE_APPLICATION_CREDENTIALS env variable to your service account key:
 
 ``` shell
 export GOOGLE_APPLICATION_CREDENTIALS=/home/hashr/hashr-sa-private-key.json
@@ -187,10 +192,10 @@ gcloud spanner databases create hashr --instance=hashr
 Allow the service account to use Spanner database, set *<project_name>* to your project name:
 
 ``` shell
-gcloud spanner databases add-iam-policy-binding hashr --instance hashr --member="serviceAccount:hashr-sa@<project_name>.iam.gserviceaccount.com" --role="roles/spanner.databaseUser" 
+gcloud spanner databases add-iam-policy-binding hashr --instance hashr --member="serviceAccount:hashr-sa@<project_name>.iam.gserviceaccount.com" --role="roles/spanner.databaseUser"
 ```
 
-Update Spanner database schema: 
+Update Spanner database schema:
 
 ``` shell
 gcloud spanner databases ddl update hashr --instance=hashr --ddl-file=scripts/CreateJobsTable.ddl
@@ -198,20 +203,20 @@ gcloud spanner databases ddl update hashr --instance=hashr --ddl-file=scripts/Cr
 
 In order to use Cloud Spanner to store information about processing tasks you need to specify the following flags: `-jobStorage cloudspanner -spannerDBPath <spanner_db_path>`
 
-### Setting up importers 
+### Setting up importers
 
 In order to specify which importer you want to run you should use the `-importers` flag. Possible values: `GCP,targz,windows,wsus,deb,rpm,zip,gcr,iso9660`
 
 #### GCP (Google Cloud Platform)
 
-This importer can extract files from GCP disk [images](https://cloud.google.com/compute/docs/images). This is done in few steps: 
+This importer can extract files from GCP disk [images](https://cloud.google.com/compute/docs/images). This is done in few steps:
 
 1. Check for new images in the target project (e.g. ubuntu-os-cloud)
 1. Copy new/unprocessed image to the hashR GCP project
 1. Run Cloud Build, which creates a temporary VM, runs dd on the copied image and saves the output to a .tar.gz file.
 1. Export raw_disk.tar.gz to the GCS bucket in hashR GCP project
 1. Copy raw_disk.tar.gz from GCS to local hashR storage
-1. Extract raw_disk.tar.gz and pass the disk image to Plaso 
+1. Extract raw_disk.tar.gz and pass the disk image to Plaso
 
 List of GCP projects containing public GCP images can be found [here](https://cloud.google.com/compute/docs/images/os-details#general-info). In order to use this importer you need to have a GCP project and follow these steps:
 
@@ -301,14 +306,14 @@ gcloud projects add-iam-policy-binding <project_name> \
   --role='roles/storage.objectAdmin'
 ```
 
-To use this importer you need to specify the following flag(s): 
+To use this importer you need to specify the following flag(s):
 
 1. `-gcpProjects` which is a comma separated list of cloud projects containing disk images. If you'd like to import public images take a look [here](https://cloud.google.com/compute/docs/images/os-details#general-info)
-1. `-hashrGCPProject` GCP project that will be used to store copy of disk images for processing and also run Cloud Build 
+1. `-hashrGCPProject` GCP project that will be used to store copy of disk images for processing and also run Cloud Build
 1. `-hashrGCSBucket` GCS bucket that will be used to store output of Cloud Build (disk images in .tar.gz format)
 
-#### GCR (Google Container Registry) 
-This importer extracts files from container images stored in GCR repositories. In order to set ip up follow these steps: 
+#### GCR (Google Container Registry)
+This importer extracts files from container images stored in GCR repositories. In order to set ip up follow these steps:
 
 Step 1: Create HashR service account, skip to step 4 if this was done while setting up other GCP dependent components.
 
@@ -328,20 +333,20 @@ Step 3: Point GOOGLE_APPLICATION_CREDENTIALS env variable to your service accoun
 export GOOGLE_APPLICATION_CREDENTIALS=~/hashr-sa-private-key.json
 ```
 
-Step 4: Grant hashR service account key required permissions to access given GCR repository. 
+Step 4: Grant hashR service account key required permissions to access given GCR repository.
 
 ``` shell
 gsutil iam ch serviceAccount:hashr-sa@<project_name>.iam.gserviceaccount.com:objectViewer gs://artifacts.<project_name_hosting_gcr_repo>.appspot.com
 ```
 
-To use this importer you need to specify the following flag(s): 
+To use this importer you need to specify the following flag(s):
 
 1. `-gcr_repos` which should contain comma separated list of GCR repositories from which you want to import the container images.
-   
-#### Windows 
 
-This importer extracts files from official Windows installation media in ISO-13346 format, e.g. the ones you can download from official Microsoft [website](https://www.microsoft.com/en-gb/software-download/windows10ISO). 
-One ISO file can contain multiple WIM images: 
+#### Windows
+
+This importer extracts files from official Windows installation media in ISO-13346 format, e.g. the ones you can download from official Microsoft [website](https://www.microsoft.com/en-gb/software-download/windows10ISO).
+One ISO file can contain multiple WIM images:
 
 1. Windows10ProEducation
 1. Windows10Education
@@ -353,13 +358,13 @@ This importer will extract files from all images it can find in the `install.wim
 
 #### WSUS
 
-This importer utilizes 7z to recursively extract contents of Windows Update packages. It will look for Windows Update files in the provided GCS bucket, easiest way to automatically update the GCS bucket with new updates would be to do the following: 
+This importer utilizes 7z to recursively extract contents of Windows Update packages. It will look for Windows Update files in the provided GCS bucket, easiest way to automatically update the GCS bucket with new updates would be to do the following:
 
-1. Set up GCE VM running Windows Server in hashr GCP project. 
+1. Set up GCE VM running Windows Server in hashr GCP project.
 1. Configure it with WSUS role, select Windows Update packages that you'd like to process
-1. Configure WSUS to automatically approve and download updates to local storage 
+1. Configure WSUS to automatically approve and download updates to local storage
 1. Set up a Windows task to automatically sync content of the local storage to the GCS bucket: `gsutil -m rsync -r D:/WSUS/WsusContent gs://hashr-wsus/` (remember to adjust the paths)
-1. If you'd like to have the filename of the update package (which usually contains KB number) as the ID (by default it's sha1, that's how MS stores WSUS updates) and its description this is something that can be dumped from the internal WID WSUS database. You can use the following Power Shell script and run it as a task: 
+1. If you'd like to have the filename of the update package (which usually contains KB number) as the ID (by default it's sha1, that's how MS stores WSUS updates) and its description this is something that can be dumped from the internal WID WSUS database. You can use the following Power Shell script and run it as a task:
 
 ```
 #SQL Query
@@ -375,43 +380,43 @@ $SqlQuery = 'select DISTINCT CONVERT([varchar](512), tbfile.FileDigest, 2) as sh
   on u.UpdateID = vu.UpdateId'
 $SqlConnection = New-Object System.Data.SqlClient.SqlConnection
 $SqlConnection.ConnectionString = 'server=\\.\pipe\MICROSOFT##WID\tsql\query;database=SUSDB;trusted_connection=true;'
-$SqlCmd = New-Object System.Data.SqlClient.SqlCommand  
-$SqlCmd.CommandText = $SqlQuery  
-$SqlCmd.Connection = $SqlConnection  
+$SqlCmd = New-Object System.Data.SqlClient.SqlCommand
+$SqlCmd.CommandText = $SqlQuery
+$SqlCmd.Connection = $SqlConnection
 $SqlCmd.CommandTimeout = 0
-$SqlAdapter = New-Object System.Data.SqlClient.SqlDataAdapter  
-$SqlAdapter.SelectCommand = $SqlCmd   
-#Creating Dataset  
-$DataSet = New-Object System.Data.DataSet  
-$SqlAdapter.Fill($DataSet)  
-$DataSet.Tables[0] | export-csv -Delimiter $delimiter -Path "D:\WSUS\WsusContent\export.csv" -NoTypeInformation 
+$SqlAdapter = New-Object System.Data.SqlClient.SqlDataAdapter
+$SqlAdapter.SelectCommand = $SqlCmd
+#Creating Dataset
+$DataSet = New-Object System.Data.DataSet
+$SqlAdapter.Fill($DataSet)
+$DataSet.Tables[0] | export-csv -Delimiter $delimiter -Path "D:\WSUS\WsusContent\export.csv" -NoTypeInformation
 
 gsutil -m rsync -r D:/WSUS/WsusContent gs://hashr-wsus/
 ```
 
-This will dump the relevant information from WSUS DB, store it in the `export.csv` file and sync the contents of the WSUS folder with GCS bucket. WSUS importer will check if `export.csv` file is present in the root of the WSUS repo, if so it will use it. 
+This will dump the relevant information from WSUS DB, store it in the `export.csv` file and sync the contents of the WSUS folder with GCS bucket. WSUS importer will check if `export.csv` file is present in the root of the WSUS repo, if so it will use it.
 
-#### TarGz 
+#### TarGz
 
-This is a simple importer that traverses repositories and looks for `.tar.gz` files. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s): 
+This is a simple importer that traverses repositories and looks for `.tar.gz` files. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s):
 
 1. `-targz_repo_path` which should point to the path on the local file system that contains `.tar.gz` files
 
-#### Deb 
+#### Deb
 
-This is very similar to the TarGz importer except that it looks for `.deb` packages. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s): 
+This is very similar to the TarGz importer except that it looks for `.deb` packages. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s):
 
 1. `-deb_repo_path` which should point to the path on the local file system that contains `.deb` files
 
 #### RPM
 
-This is very similar to the TarGz importer except that it looks for `.rpm` packages. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s): 
+This is very similar to the TarGz importer except that it looks for `.rpm` packages. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s):
 
 1. `-rpm_repo_path` which should point to the path on the local file system that contains `.rpm` files
 
 #### Zip (and other zip-like formats)
 
-This is very similar to the TarGz importer except that it looks for `.zip` archives. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s): 
+This is very similar to the TarGz importer except that it looks for `.zip` archives. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s):
 
 1. `-zip_repo_path` which should point to the path on the local file system that contains `.zip` files
 
@@ -421,43 +426,43 @@ Optionally, you can also set the following flag(s):
 
 #### ISO 9660
 
-This is very similar to the TarGz importer except that it looks for `.iso` file. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s): 
+This is very similar to the TarGz importer except that it looks for `.iso` file. Once found it will hash the first and the last 10MB of the file to check if it was already processed. This is done to prevent hashing the whole file every time the repository is scanned for new sources. To use this importer you need to specify the following flag(s):
 
 1. `-iso_repo_path` which should point to the path on the local file system that contains `.iso` files
 
-### Setting up exporters 
+### Setting up exporters
 
-#### Setting up Postgres exporter 
+#### Setting up Postgres exporter
 
-Postgres exporter allows sending of hashes, file metadata and the actual content of the file to a PostgreSQL instance. For best performance it's advised to set it up on a separate and dedicated machine. 
-If you did set up PostgreSQL while choosing the processing jobs storage you're almost good to go, just run the following command to create the required tables: 
+Postgres exporter allows sending of hashes, file metadata and the actual content of the file to a PostgreSQL instance. For best performance it's advised to set it up on a separate and dedicated machine.
+If you did set up PostgreSQL while choosing the processing jobs storage you're almost good to go, just run the following command to create the required tables:
 ``` shell
 cat scripts/CreatePostgresExporterTables.sql | docker exec -i hashr_postgresql psql -U hashr -d hashr
 ```
-If you didn't choose Postgres for processing job storage follow steps 1 & 2 from the [Setting up PostgreSQL storage](####setting-up-postgresql-storage) section. 
+If you didn't choose Postgres for processing job storage follow steps 1 & 2 from the [Setting up PostgreSQL storage](####setting-up-postgresql-storage) section.
 
-This is currently the default exporter, you don't need to explicitly enable it. By default the content of the actual files won't be uploaded to PostgreSQL DB, if you wish to change that use `-upload_payloads true` flag. 
+This is currently the default exporter, you don't need to explicitly enable it. By default the content of the actual files won't be uploaded to PostgreSQL DB, if you wish to change that use `-upload_payloads true` flag.
 
 In order for the Postgres exporter to work you need to set the following flags: `-exporters postgres -postgresHost <host> -postgresPort <port> -postgresUser <user> -postgresPassword <pass> -postgresDBName <db_name>`
 
-#### Setting up GCP exporter 
+#### Setting up GCP exporter
 
-GCP exporter allows sending of hashes, file metadata to GCP Spanner instance. Optionally you can upload the extracted files to GCS bucket. If you haven't set up Cloud Spanner for storing processing jobs, follow the steps in [Setting up Cloud Spanner](####setting-up-cloud-spanner) and instead of the last step run the following command to create necessary tables: 
+GCP exporter allows sending of hashes, file metadata to GCP Spanner instance. Optionally you can upload the extracted files to GCS bucket. If you haven't set up Cloud Spanner for storing processing jobs, follow the steps in [Setting up Cloud Spanner](####setting-up-cloud-spanner) and instead of the last step run the following command to create necessary tables:
 
 ``` shell
 gcloud spanner databases ddl update hashr --instance=hashr --ddl-file=scripts/CreateCloudSpannerExporterTables.ddl
 ```
 
-If you have already set up Cloud Spanner for storing jobs data you just need to the run the command above and you're ready to go. 
+If you have already set up Cloud Spanner for storing jobs data you just need to the run the command above and you're ready to go.
 
 If you'd like to upload the extracted files to GCS you need to create the GCS bucket:
 
-Step 1: Make the service account admin of this bucket: 
+Step 1: Make the service account admin of this bucket:
 ``` shell
 gsutil mb -p project_name> gs://<gcs_bucket_name>
 ```
 
-Step 2: Make the service account admin of this bucket: 
+Step 2: Make the service account admin of this bucket:
 ``` shell
 gsutil iam ch serviceAccount:hashr-sa@<project_name>.iam.gserviceaccount.com:objectAdmin gs://<gcs_bucket_name>
 ```
@@ -466,11 +471,11 @@ To use this exporter you need to provide the following flags: `-exporters GCP -g
 
 ### Additional flags
 
-1. `-processing_worker_count`: This flag controls number of parallel processing workers. Processing is CPU and I/O heavy, during my testing I found that having 2 workers is the most optimal solution. 
+1. `-processing_worker_count`: This flag controls number of parallel processing workers. Processing is CPU and I/O heavy, during my testing I found that having 2 workers is the most optimal solution.
 1. `-cache_dir`: Location of local cache used for deduplication, it's advised to change that from `/tmp` to e.g. home directory of the user that will be running hashr.
-1. `-export`: When set to false hashr will save the results to disk bypassing the exporter. 
+1. `-export`: When set to false hashr will save the results to disk bypassing the exporter.
 1. `-export_path`: If export is set to false, this is the folder where samples will be saved.
-1. `-reprocess`: Allows to reprocess a given source (in case it e.g. errored out) based on the sha256 value stored in the jobs table. 
+1. `-reprocess`: Allows to reprocess a given source (in case it e.g. errored out) based on the sha256 value stored in the jobs table.
 1. `-upload_payloads`: Controls if the actual content of the file will be uploaded by defined exporters.
 2. `-gcp_exporter_worker_count`: Number of workers/goroutines that the GCP exporter will use to upload the data.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,112 @@
+# HashR in docker
+
+Follow these steps to set-up HashR running in a docker container.
+
+If you want a local installation, check [these steps](https://github.com/google/hashr#setting-up-hashr).
+
+## Table of contents
+
+* [Pull the HashR image](#pull-the-hashr-image)
+* [Setup a database and importers](#setup-a-database-and-importers)
+    * [Database](#database)
+    * [Importers](#importers)
+    * [Docker networking](#docker-networking)
+* [Run HashR](#run-hashr)
+    * [Examples](#examples)
+
+
+## Pull the HashR image
+
+The HashR docker image will provide the HashR binary and tools it needs to
+work.
+
+By default the latest tagged release will be pulled if not specified otherwise:
+
+```shell
+docker pull us-docker.pkg.dev/osdfir-registry/hashr/release/hashr
+```
+
+Pulling a specific release tag:
+
+```shell
+docker pull us-docker.pkg.dev/osdfir-registry/hashr/release/hashr:v1.7.1
+```
+
+## Setup a database and importers
+
+### Database
+
+You still need to provide your own database for HashR to store the results.
+Check the [Setting up storage for processing tasks](https://github.com/google/hashr#setting-up-storage-for-processing-tasks) step in the local installation
+guide.
+
+### Importers
+
+Follow the [Setting up importers](https://github.com/google/hashr#setting-up-importers)
+guide to setup the importers you want to use.
+
+Come back here for running HashR in docker with specific importers.
+
+### Docker networking
+
+Create a docker network that will be used by `hashr_postgresql` and the `hashr`
+container.
+
+```shell
+docker network create hashr_net
+```
+
+```shell
+docker network connect hashr_net hashr_postgresql
+```
+
+## Run HashR
+
+Get all availalbe HashR flags
+
+```shell
+docker run us-docker.pkg.dev/osdfir-registry/hashr/release/hashr -h
+```
+
+### Examples
+
+> **NOTE**
+Ensure that the host directory mapped into `/data/` in the container is
+readable for all!
+
+Run HashR using the `iso9660` importer and export results to PostgreSQL:
+
+```shell
+docker run -it \
+  --network hashr_net \
+  -v ${pwd}/ISO:/data/iso \
+  us-docker.pkg.dev/osdfir-registry/hashr/release/hashr \
+  -storage postgres \
+    -postgres_host hashr_postgresql \
+    -postgres_port 5432 \
+    -postgres_user hashr \
+    -postgres_password hashr \
+    -postgres_db hashr \
+  -importers iso9660 \
+    -iso_repo_path /data/iso/ \
+  -exporters postgres
+```
+
+Run hashr using the `deb` importer and export results to PostgreSQL:
+
+```shell
+docker run -it \
+  --network hashr_net \
+  -v ${pwd}/DEB:/data/deb \
+  us-docker.pkg.dev/osdfir-registry/hashr/release/hashr \
+  -storage postgres \
+    -postgres_host hashr_postgresql \
+    -postgres_port 5432 \
+    -postgres_user hashr \
+    -postgres_password hashr \
+    -postgres_db hashr \
+  -importers deb \
+    -deb_repo_path /data/deb/ \
+  -exporters postgres
+```
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,9 @@ If you want a local installation, check [these steps](https://github.com/google/
 
 ## Table of contents
 
-* [Pull the HashR image](#pull-the-hashr-image)
+* [HashR docker image](#hashr-docker-image)
+  * [Pull the HashR image](#pull-the-hashr-image)
+  * [Build the HashR image](#build-the-hashr-image)
 * [Setup a database and importers](#setup-a-database-and-importers)
     * [Database](#database)
     * [Importers](#importers)
@@ -15,7 +17,11 @@ If you want a local installation, check [these steps](https://github.com/google/
     * [Examples](#examples)
 
 
-## Pull the HashR image
+## HashR docker image
+
+You can either use our hosted docker image or build it yourself.
+
+### Pull the HashR image
 
 The HashR docker image will provide the HashR binary and tools it needs to
 work.
@@ -30,6 +36,14 @@ Pulling a specific release tag:
 
 ```shell
 docker pull us-docker.pkg.dev/osdfir-registry/hashr/release/hashr:v1.7.1
+```
+
+### Build the HashR image
+
+From the repository root folder run the following command:
+
+```shell
+docker build -f docker/Dockerfile .
 ```
 
 ## Setup a database and importers


### PR DESCRIPTION
This PR adds documentation to the docker folder on how to setup and use HashR with docker.
* Changes to the main readme are mainly formatting and one link to the docker guide.