### PR TITLE
Adding a cloudbuild config

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -1,0 +1,19 @@
+# Google Cloud Build configuration for HashR release
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "build",
+        "-t",
+        "us-docker.pkg.dev/osdfir-registry/hashr/release/hashr:$TAG_NAME",
+        "-t",
+        "us-docker.pkg.dev/osdfir-registry/hashr/release/hashr:latest",
+        "-f",
+        "docker/Dockerfile",
+        ".",
+      ]
+    timeout: 4800s
+timeout: 4800s
+images:
+  - us-docker.pkg.dev/osdfir-registry/hashr/release/hashr:latest
+  - us-docker.pkg.dev/osdfir-registry/hashr/release/hashr:$TAG_NAME


### PR DESCRIPTION
This PR adds a `cloudbuild.yaml` config file. This will be used to build docker images and also automatically set the `latest` tag.