### PR TITLE
Improve docker check

### DIFF
--- a/processors/local/local.go
+++ b/processors/local/local.go
@@ -77,6 +77,6 @@ func (p *Processor) ImageExport(sourcePath string) (string, error) {
 }
 
 func inDockerContainer() bool {
-	_, err := shellCommand("ls", "/.dockerenv")
+	_, err := shellCommand("which", "image_export.py")
 	return err == nil
 }


### PR DESCRIPTION
Using `which image_export.py` instead of `ls /.dockerenv` allows to check for what is actually relevant: Is there a local image_export version available or does HashR need to use a docker container. This change enables running HashR on GKE for example.

closes #70 